### PR TITLE
missing next_line on array and sparse switch

### DIFF
--- a/smali/reader.py
+++ b/smali/reader.py
@@ -881,8 +881,8 @@ class SmaliReader:
         if do_copy:
             self._copy_line()
         self._publish_comment()
-        self._next_line()
         while True:
+            self._next_line()
             value = self.line.peek()
             self._publish_comment()
             if do_copy:
@@ -929,8 +929,8 @@ class SmaliReader:
         if do_copy:
             self._copy_line()
         self._publish_comment()
-        self._next_line()
         while True:
+            self._next_line()
             key = self.line.peek()
             self._publish_comment()
             if do_copy:


### PR DESCRIPTION
Thanks for the greate lib. During an apk parse, the library was looping forever in the following 2 example structures. The issue was that inside the `while True:` of the `_handle_sparse_switch` and `_handle_array_data` there was no `self._next_line()` command

``` smali
    .sparse-switch
        -0x7404ceea -> :sswitch_d
        -0x56c015e7 -> :sswitch_c
        -0x503aa7ad -> :sswitch_b
        -0x37f7066e -> :sswitch_a
        -0x37e04bb3 -> :sswitch_9
        -0x274065a5 -> :sswitch_8
        -0x1440b607 -> :sswitch_7
        0x2e46a6ed -> :sswitch_6
        0x2fa453c6 -> :sswitch_5
        0x431b5280 -> :sswitch_4
        0x5445f9ba -> :sswitch_3
        0x5f7507c3 -> :sswitch_2
        0x63577677 -> :sswitch_1
        0x77471352 -> :sswitch_0
    .end sparse-switch

    .array-data 4
        0x101011c
        0x1010194
        0x1010195
        0x1010196
        0x101030c
        0x101030d
    .end array-data
```