### PR TITLE
Base.py get method params

### DIFF
--- a/smali/base.py
+++ b/smali/base.py
@@ -425,35 +425,15 @@ class Type:
         :rtype: list
         """
         start = self.__signature.find("(")
-        end = self.__signature.find(")") + 1
-        if start == -1 or end == -1:
+        end = self.__signature.find(")")
+        if start == -1 or end == -1 or (end < start):
             raise TypeError("Invalid method signature")
 
         params = self.__signature[start + 1 : end]
-        if not params:
-            return []
 
-        param_list = []
-        current_param = ""
-        is_type_def = False
-        for char in params:
-            current_param = f"{current_param}{char}"
+        d = ";"
+        param_list = [param + d for param in params.split(d) if param]
 
-            if char == "L":
-                is_type_def = True
-                continue
-
-            if char == "[" or is_type_def:
-                continue
-
-            if char == ";":
-                is_type_def = False
-
-            param_list.append(current_param)
-            current_param = ""
-
-        if current_param:
-            param_list.append(current_param)
         return param_list
 
     def get_method_return_type(self) -> str:

--- a/smali/base.py
+++ b/smali/base.py
@@ -431,8 +431,8 @@ class Type:
 
         params = self.__signature[start + 1 : end]
 
-        d = ";"
-        param_list = [param + d for param in params.split(d) if param]
+        delimiter = ";"
+        param_list = [param + delimiter for param in params.split(delimiter) if param]
 
         return param_list
 


### PR DESCRIPTION
I had an issue with the get_method_params in base Type. The returning params where always returning in a single list index concatenated with a bracket at the end.

* I reduced the value of the end index to remove the bracket at the end. These may not affect the smali write module as it explicitly sets the param brackets.
* I modified the param split logic to list comprehension based on the ';' delimiter that each param has. These help with the parameter split and also i believe covers all possible type descriptors that can exist in the beginning of the param.
* Added an additional guard in method signature check.