### PR TITLE
Minor fixes and tricks

### DIFF
--- a/smali/base.py
+++ b/smali/base.py
@@ -723,7 +723,7 @@ RE_TYPE_VALUE = re.compile(r"\[*((L\S*;$)|([ZCBSIFVJD])$)")  # NOQA
 RE_BOOL_VALUE = re.compile(r"true|false")
 """Pattern for ``boolean`` values."""
 
-RE_HEX_VALUE = re.compile(r"0x[\dabcdefABCDEF]+")
+RE_HEX_VALUE = re.compile(r"[\-\+]?0x[\dabcdefABCDEF]+")
 """Pattern for integer values."""
 
 TYPE_MAP: list = [
@@ -735,7 +735,7 @@ TYPE_MAP: list = [
     (RE_FLOAT_VALUE, lambda x: float(x[:-1])),
     (RE_DOUBLE_VALUE, lambda x: float(x[:-1])),
     (RE_CHAR_VALUE, lambda x: str(x[1:-1])),
-    (RE_STRING_VALUE, lambda x: str(x[1:-1])),
+    (RE_STRING_VALUE, lambda x: str(x[1:-1]).encode().decode('unicode_escape')), # support unicode
     (RE_TYPE_VALUE, SVMType),
 ]
 """Defines custom handlers for actual value defintions

--- a/smali/bridge/objects.py
+++ b/smali/bridge/objects.py
@@ -30,3 +30,17 @@ Class = {
     "getName()Ljava/lang/String;": lambda x: x.simple_name
 }
 
+def java_lang_String_hashCode(text):
+    sign = 1 << 31
+    hashCode = sum(ord(t)*31**i for i, t in enumerate(reversed(text)))
+    return (hashCode & sign-1) - (hashCode & sign)
+
+String = {
+    "hashCode()I": java_lang_String_hashCode,
+}
+
+implementations = {
+    "Ljava/lang/Class;": Class,
+    "Ljava/lang/Object;": Object,
+    "Ljava/lang/String;": String,
+}


### PR DESCRIPTION
While running some disassembled smali code I stumbled upon some bugs/inconsistencies in pysmali.

Overview:
- Hex values regex now support negative and positive numbers (e.g. `const v1, -0x1`)
- String regex now support handling of unicode strings (e.g. `const-string v0, "\u06e4\u06eb"`)
- Refactored direct-call implementations for Object and Class (it was essentially redundant code)
- Added `move_object` executor
- Fixed `sparse_switch` executor that was not executed due to a typo
- Added `java.lang.String.hashCode()` implementation as a direct-call