### PR TITLE
fix: Add missing .end directives of array-data, packed-switch and sparse-switch for MethodWriter.

### DIFF
--- a/smali/writer.py
+++ b/smali/writer.py
@@ -422,7 +422,6 @@ class _SmaliMethodWriter(MethodVisitor, _ContainsCodeCache):
         super().visit_array_data(length, value_list)
         indent_value = self.cache.default_indent * (self.cache.indent + 2)
         sep_value = "\n" + indent_value
-        value_list = map(hex, value_list)
         self.cache.add(
             f".{Token.ARRAYDATA} {length}\n{indent_value}{sep_value.join(value_list)}\n.{Token.END} {Token.ARRAYDATA}",
             end="\n",

--- a/smali/writer.py
+++ b/smali/writer.py
@@ -433,7 +433,7 @@ class _SmaliMethodWriter(MethodVisitor, _ContainsCodeCache):
         indent_value = self.cache.default_indent * (self.cache.indent + 2)
         sep_value = "\n" + indent_value + ":"
         self.cache.add(
-            f".{Token.PACKEDSWITCH} {value}\n{indent_value}{sep_value.join(blocks)}",
+            f".{Token.PACKEDSWITCH} {value}\n{indent_value}:{sep_value.join(blocks)}\n.{Token.END} {Token.PACKEDSWITCH}",
             end="\n",
         )
 
@@ -443,7 +443,7 @@ class _SmaliMethodWriter(MethodVisitor, _ContainsCodeCache):
         indent_value = self.cache.default_indent * (self.cache.indent + 2)
         values = [f"{x} -> :{y}" for x, y in branches.items()]
         sep_value = "\n" + indent_value
-        self.cache.add(f".{Token.SPARSESWITCH}\n{indent_value}{sep_value.join(values)}")
+        self.cache.add(f".{Token.SPARSESWITCH}\n{indent_value}{sep_value.join(values)}\n.{Token.END} {Token.SPARSESWITCH}")
 
     def visit_eol_comment(self, text: str) -> None:
         super().visit_eol_comment(text)

--- a/smali/writer.py
+++ b/smali/writer.py
@@ -422,8 +422,9 @@ class _SmaliMethodWriter(MethodVisitor, _ContainsCodeCache):
         super().visit_array_data(length, value_list)
         indent_value = self.cache.default_indent * (self.cache.indent + 2)
         sep_value = "\n" + indent_value
+        value_list = map(hex, value_list)
         self.cache.add(
-            f".{Token.ARRAYDATA} {length}\n{indent_value}{sep_value.join(value_list)}",
+            f".{Token.ARRAYDATA} {length}\n{indent_value}{sep_value.join(value_list)}\n.{Token.END} {Token.ARRAYDATA}",
             end="\n",
         )
 


### PR DESCRIPTION
As title.