### PR TITLE
[FIX] Typing and bug fixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,17 @@
 Changelog
 *********
 
+.. _release-0.2.7:
+
+0.2.7
+-----
+
+Some small bug fixes and behavior changes in :class:`_SmaliClassWriter`
+
+* Fixed a bug where the default classloader would be used everytime in a :class:`SmaliVM` instance
+* Fixed a bug in :code:`SmaliClass.fields()` where a call to :code:`.items()` was missing
+* :class:`_SmaliClassWriter`, :class:`_SmaliMethodWriter`, :class:`_SmaliFieldWriter` and :class:`_SmaliAnnotationWriter` now return the result of the delegate visitor instead of a new one if the delegate is an instance of the target writer class.
+
 .. _release-0.2.6:
 
 0.2.6

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ author = 'MatrixEditor'
 # The short X.Y version.
 version = '0.2'
 # The full version, including alpha/beta/rc tags.
-release = '0.2.6'
+release = '0.2.7'
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/examples/rewrite.py
+++ b/examples/rewrite.py
@@ -1,0 +1,33 @@
+from typing import Optional
+from smali import SmaliReader, SmaliWriter, MethodWriter
+
+
+class CustomInstructionsWriter(MethodWriter):
+    def __init__(self, delegate=None, indent=0) -> None:
+        super().__init__(delegate, indent)
+
+    # if you know the structure, it will be easy to install
+    # the right hook
+    def visit_registers(self, registers: int) -> None:
+        super().visit_registers(registers)
+        # add custom instruction
+        self.visit_locals(1000)
+
+
+class CustomWriter(SmaliWriter):
+    def visit_method(
+        self, name: str, access_flags: int, parameters: list, return_type: str
+    ) -> Optional[MethodWriter]:
+        if name == "main":
+            return CustomInstructionsWriter()
+
+
+
+reader = SmaliReader(comments=False)
+writer = SmaliWriter(reader, delegate=CustomWriter())
+
+with open("rewrite.smali", "r", encoding="utf-8") as fp:
+    source = fp.read()
+
+reader.visit(source, writer)
+print(writer.code)

--- a/examples/rewrite.smali
+++ b/examples/rewrite.smali
@@ -1,0 +1,9 @@
+.class public final Lcom/example/Example;
+.super Ljava/lang/Object;
+.source "Example.java"
+
+.method public static main([Ljava/lang/String;)V
+    .registers 1
+
+    return-void
+.end method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pysmali"
-version = "0.2.6"
+version = "0.2.7"
 description="Smali Visitor-API and Smali emulator"
 authors = [
   { name="MatrixEditor", email="not@supported.com" },

--- a/smali/__init__.py
+++ b/smali/__init__.py
@@ -25,4 +25,4 @@ from smali.writer import *
 
 SmaliValue = smali_value
 
-VERSION = '0.2.6'
+VERSION = '0.2.7'

--- a/smali/base.py
+++ b/smali/base.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
+from typing import Any
 
 __doc__ = """
 Basic component classes when working with the Smali language.
@@ -207,7 +208,7 @@ class Line:
     eol_comment: str
     """The removed trailing EOL comment (if present)"""
 
-    def __init__(self, line: str) -> None:
+    def __init__(self, line: str | None) -> None:
         if isinstance(line, (bytearray, bytes)):
             line = line.decode()
 
@@ -216,13 +217,13 @@ class Line:
         self._elements = []
         self.reset(line)
 
-    def _get_next(self) -> str:
+    def _get_next(self) -> str | Any:
         try:
             return next(self._it)
         except StopIteration:
             return self._default
 
-    def __next__(self) -> str:
+    def __next__(self) -> str | Any:
         value = self._head
         if value == self._default:
             raise StopIteration()
@@ -230,7 +231,7 @@ class Line:
         self._head = self._get_next()
         return value
 
-    def reset(self, line: str = None) -> None:
+    def reset(self, line: str | None = None) -> None:
         """Resets this line and/or initialized it with the new value.
 
         :param line: the next line, defaults to None
@@ -258,7 +259,7 @@ class Line:
         self._it = iter(self._elements)
         self._head = self._get_next()
 
-    def peek(self, default: str = _default) -> str:
+    def peek(self, default: str | Any = _default) -> str | Any:
         """Returns the current element if this line.
 
         This method won't move forwards.
@@ -605,7 +606,7 @@ class SVMType:
         return self.__class
 
     @property
-    def array_type(self) -> SVMType:
+    def array_type(self) -> SVMType | None:
         """Returns the underlying array type (if any)
 
         >>> array = SVMType("[[B")

--- a/smali/bridge/vm.py
+++ b/smali/bridge/vm.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
+from typing import Optional
 
 __doc__ = """
 Implementation of a simple Smali emulator named *SmaliVM*. It supports
@@ -111,7 +112,7 @@ class SmaliVM:
     classloader: ClassLoader
     """The class loader used to define classes."""
 
-    debug_handler: DebugHandler
+    debug_handler: Optional[DebugHandler]
     """The debug handler to use."""
 
     executors: dict[str, executor.Executor]
@@ -152,11 +153,11 @@ class SmaliVM:
 
     def __init__(
         self,
-        class_loader: ClassLoader = None,
-        executors: dict = None,
+        class_loader: Optional[ClassLoader] = None,
+        executors: Optional[dict[str, executor.Executor]] = None,
         use_strict: bool = False,
     ) -> None:
-        self.classloader = _SmaliClassLoader(self) or class_loader
+        self.classloader = class_loader or _SmaliClassLoader(self)
         self.executors = executors or executor.cache
         self.use_strict = use_strict
         self.debug_handler = None

--- a/smali/reader.py
+++ b/smali/reader.py
@@ -20,6 +20,7 @@ routine.
 """
 
 import io
+from typing import Optional
 
 from smali.visitor import (
     VisitorBase,
@@ -93,7 +94,7 @@ class SmaliReader:
     errors: str = "strict"
     """Indicates whether this reader should throw errors (values: 'strict', 'ignore')"""
 
-    copy_handler: SupportsCopy
+    copy_handler: Optional[SupportsCopy]
 
     def __init__(
         self,
@@ -152,7 +153,7 @@ class SmaliReader:
         self._do_visit()
 
     @property
-    def _visitor(self) -> VisitorBase:
+    def _visitor(self) -> VisitorBase[ClassVisitor | FieldVisitor | MethodVisitor | AnnotationVisitor]:
         """Returns the active visitor instance.
 
         :return: the active visitor.
@@ -181,8 +182,11 @@ class SmaliReader:
             if len(raw_line) == 0:
                 raise EOFError()
 
-            if isinstance(raw_line, bytes):
+            # REVISIT: what about encodings?
+            if isinstance(raw_line, (bytes, bytearray)):
                 raw_line = raw_line.decode()
+            elif isinstance(raw_line, memoryview):
+                raw_line = raw_line.tobytes().decode()
 
             # Sort out blank lines without anything
             if not raw_line:


### PR DESCRIPTION
* Fixed a bug where the default classloader would be used everytime in a `SmaliVM` instance
* Fixed a bug in `SmaliClass.fields()` where a call to `.items()` was missing
* `_SmaliClassWriter`, `_SmaliMethodWriter`,`_SmaliFieldWriter` and `_SmaliAnnotationWriter` now return the result of the delegate visitor instead of a new one if the delegate is an instance of the target writer class.
